### PR TITLE
logging: replace glog with klog

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -415,7 +415,7 @@
 [[projects]]
   branch = "master"
   digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
-  name = "github.com/golang/glog"
+  name = "k8s.io/klog"
   packages = ["."]
   pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
@@ -1599,7 +1599,7 @@
     "github.com/fatih/structs",
     "github.com/fsnotify/fsnotify",
     "github.com/go-openapi/spec",
-    "github.com/golang/glog",
+    "k8s.io/klog",
     "github.com/google/go-cmp/cmp",
     "github.com/jpillora/go-ogle-analytics",
     "github.com/json-iterator/go",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/golang/glog"
+  name = "k8s.io/klog"
 
 [[constraint]]
   branch = "master"

--- a/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	reg "k8s.io/api/admissionregistration/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -25,7 +25,7 @@ import (
 func CreateOrPatchMutatingWebhookConfiguration(c kubernetes.Interface, name string, transform func(*reg.MutatingWebhookConfiguration) *reg.MutatingWebhookConfiguration) (*reg.MutatingWebhookConfiguration, kutil.VerbType, error) {
 	cur, err := c.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating MutatingWebhookConfiguration %s.", name)
+		klog.V(3).Infof("Creating MutatingWebhookConfiguration %s.", name)
 		out, err := c.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(transform(&reg.MutatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "MutatingWebhookConfiguration",
@@ -64,7 +64,7 @@ func PatchMutatingWebhookConfigurationObject(c kubernetes.Interface, cur, mod *r
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching MutatingWebhookConfiguration %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching MutatingWebhookConfiguration %s with %s.", cur.Name, string(patch))
 	out, err := c.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -80,7 +80,7 @@ func TryUpdateMutatingWebhookConfiguration(c kubernetes.Interface, name string, 
 			result, e2 = c.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update MutatingWebhookConfiguration %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update MutatingWebhookConfiguration %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 
@@ -128,7 +128,7 @@ func UpdateMutatingWebhookCABundle(config *rest.Config, webhookConfigName string
 					return in
 				})
 				if err != nil {
-					glog.Warning(err)
+					klog.Warning(err)
 				}
 				return err == nil, err
 			default:
@@ -187,7 +187,7 @@ func SyncMutatingWebhookCABundle(config *rest.Config, webhookConfigName string) 
 					return in
 				})
 				if err != nil {
-					glog.Warning(err)
+					klog.Warning(err)
 				}
 				return false, nil // continue
 			default:

--- a/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	reg "k8s.io/api/admissionregistration/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -25,7 +25,7 @@ import (
 func CreateOrPatchValidatingWebhookConfiguration(c kubernetes.Interface, name string, transform func(*reg.ValidatingWebhookConfiguration) *reg.ValidatingWebhookConfiguration) (*reg.ValidatingWebhookConfiguration, kutil.VerbType, error) {
 	cur, err := c.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating ValidatingWebhookConfiguration %s.", name)
+		klog.V(3).Infof("Creating ValidatingWebhookConfiguration %s.", name)
 		out, err := c.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(transform(&reg.ValidatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ValidatingWebhookConfiguration",
@@ -64,7 +64,7 @@ func PatchValidatingWebhookConfigurationObject(c kubernetes.Interface, cur, mod 
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching ValidatingWebhookConfiguration %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching ValidatingWebhookConfiguration %s with %s.", cur.Name, string(patch))
 	out, err := c.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -80,7 +80,7 @@ func TryUpdateValidatingWebhookConfiguration(c kubernetes.Interface, name string
 			result, e2 = c.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update ValidatingWebhookConfiguration %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update ValidatingWebhookConfiguration %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 
@@ -128,7 +128,7 @@ func UpdateValidatingWebhookCABundle(config *rest.Config, webhookConfigName stri
 					return in
 				})
 				if err != nil {
-					glog.Warning(err)
+					klog.Warning(err)
 				}
 				return err == nil, err
 			default:
@@ -187,7 +187,7 @@ func SyncValidatingWebhookCABundle(config *rest.Config, webhookConfigName string
 					return in
 				})
 				if err != nil {
-					glog.Warning(err)
+					klog.Warning(err)
 				}
 				return false, nil // continue
 			default:

--- a/admissionregistration/v1beta1/xray.go
+++ b/admissionregistration/v1beta1/xray.go
@@ -11,7 +11,7 @@ import (
 	dynamic_util "github.com/appscode/kutil/dynamic"
 	meta_util "github.com/appscode/kutil/meta"
 	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"k8s.io/api/admissionregistration/v1beta1"
@@ -157,7 +157,7 @@ func (d ValidatingWebhookXray) IsActive() error {
 				if err != nil {
 					// log failures only if xray fails, otherwise don't confuse users with intermediate failures.
 					for _, msg := range failures {
-						glog.Warningln(msg)
+						klog.Warningln(msg)
 					}
 				}
 				return active, err
@@ -229,7 +229,7 @@ func (d ValidatingWebhookXray) check() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	glog.Infof("testing ValidatingWebhook using an object with GVR = %s", gvr.String())
+	klog.Infof("testing ValidatingWebhook using an object with GVR = %s", gvr.String())
 
 	accessor, err := meta.Accessor(d.testObj)
 	if err != nil {
@@ -257,7 +257,7 @@ func (d ValidatingWebhookXray) check() (bool, error) {
 	if d.op == v1beta1.Create {
 		_, err := ri.Create(&u, metav1.CreateOptions{})
 		if kutil.AdmissionWebhookDeniedRequest(err) {
-			glog.V(10).Infof("failed to create invalid test object as expected with error: %s", err)
+			klog.V(10).Infof("failed to create invalid test object as expected with error: %s", err)
 			return true, nil
 		} else if err != nil {
 			return false, err
@@ -287,7 +287,7 @@ func (d ValidatingWebhookXray) check() (bool, error) {
 		defer dynamic_util.WaitUntilDeleted(ri, d.stopCh, accessor.GetName())
 
 		if kutil.AdmissionWebhookDeniedRequest(err) {
-			glog.V(10).Infof("failed to update test object as expected with error: %s", err)
+			klog.V(10).Infof("failed to update test object as expected with error: %s", err)
 			return true, nil
 		} else if err != nil {
 			return false, err
@@ -322,7 +322,7 @@ func (d ValidatingWebhookXray) check() (bool, error) {
 				dynamic_util.WaitUntilDeleted(ri, d.stopCh, accessor.GetName())
 			}()
 
-			glog.V(10).Infof("failed to delete test object as expected with error: %s", err)
+			klog.V(10).Infof("failed to delete test object as expected with error: %s", err)
 			return true, nil
 		} else if err != nil {
 			return false, err

--- a/apiregistration/v1beta1/apiservice.go
+++ b/apiregistration/v1beta1/apiservice.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchAPIService(c apireg_cs.Interface, name string, transform func(*reg.APIService) *reg.APIService) (*reg.APIService, kutil.VerbType, error) {
 	cur, err := c.ApiregistrationV1beta1().APIServices().Get(name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating APIService %s.", name)
+		klog.V(3).Infof("Creating APIService %s.", name)
 		out, err := c.ApiregistrationV1beta1().APIServices().Create(transform(&reg.APIService{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "APIService",
@@ -55,7 +55,7 @@ func PatchAPIServiceObject(c apireg_cs.Interface, cur, mod *reg.APIService) (*re
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching APIService %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching APIService %s with %s.", cur.Name, string(patch))
 	out, err := c.ApiregistrationV1beta1().APIServices().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -71,7 +71,7 @@ func TryUpdateAPIService(c apireg_cs.Interface, name string, transform func(*reg
 			result, e2 = c.ApiregistrationV1beta1().APIServices().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update APIService %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update APIService %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/apps/v1/daemonset.go
+++ b/apps/v1/daemonset.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchDaemonSet(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*apps.DaemonSet) *apps.DaemonSet) (*apps.DaemonSet, kutil.VerbType, error) {
 	cur, err := c.AppsV1().DaemonSets(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating DaemonSet %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating DaemonSet %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.AppsV1().DaemonSets(meta.Namespace).Create(transform(&apps.DaemonSet{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "DaemonSet",
@@ -53,7 +53,7 @@ func PatchDaemonSetObject(c kubernetes.Interface, cur, mod *apps.DaemonSet) (*ap
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching DaemonSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching DaemonSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.AppsV1().DaemonSets(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateDaemonSet(c kubernetes.Interface, meta metav1.ObjectMeta, transfor
 			result, e2 = c.AppsV1().DaemonSets(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update DaemonSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update DaemonSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/apps/v1/deployment.go
+++ b/apps/v1/deployment.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/appscode/go/types"
 	"github.com/appscode/kutil"
 	core_util "github.com/appscode/kutil/core/v1"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -18,7 +18,7 @@ import (
 func CreateOrPatchDeployment(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*apps.Deployment) *apps.Deployment) (*apps.Deployment, kutil.VerbType, error) {
 	cur, err := c.AppsV1().Deployments(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Deployment %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Deployment %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.AppsV1().Deployments(meta.Namespace).Create(transform(&apps.Deployment{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Deployment",
@@ -55,7 +55,7 @@ func PatchDeploymentObject(c kubernetes.Interface, cur, mod *apps.Deployment) (*
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Deployment %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching Deployment %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.AppsV1().Deployments(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -71,7 +71,7 @@ func TryUpdateDeployment(c kubernetes.Interface, meta metav1.ObjectMeta, transfo
 			result, e2 = c.AppsV1().Deployments(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update Deployment %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update Deployment %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/apps/v1/replicaset.go
+++ b/apps/v1/replicaset.go
@@ -3,7 +3,7 @@ package v1
 import (
 	. "github.com/appscode/go/types"
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -17,7 +17,7 @@ import (
 func CreateOrPatchReplicaSet(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*apps.ReplicaSet) *apps.ReplicaSet) (*apps.ReplicaSet, kutil.VerbType, error) {
 	cur, err := c.AppsV1().ReplicaSets(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating ReplicaSet %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating ReplicaSet %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.AppsV1().ReplicaSets(meta.Namespace).Create(transform(&apps.ReplicaSet{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ReplicaSet",
@@ -54,7 +54,7 @@ func PatchReplicaSetObject(c kubernetes.Interface, cur, mod *apps.ReplicaSet) (*
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching ReplicaSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching ReplicaSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.AppsV1().ReplicaSets(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -70,7 +70,7 @@ func TryUpdateReplicaSet(c kubernetes.Interface, meta metav1.ObjectMeta, transfo
 			result, e2 = c.AppsV1().ReplicaSets(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update ReplicaSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update ReplicaSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/apps/v1/statefulset.go
+++ b/apps/v1/statefulset.go
@@ -5,7 +5,7 @@ import (
 	atypes "github.com/appscode/go/types"
 	"github.com/appscode/kutil"
 	core_util "github.com/appscode/kutil/core/v1"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -19,7 +19,7 @@ import (
 func CreateOrPatchStatefulSet(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*apps.StatefulSet) *apps.StatefulSet) (*apps.StatefulSet, kutil.VerbType, error) {
 	cur, err := c.AppsV1().StatefulSets(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating StatefulSet %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating StatefulSet %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.AppsV1().StatefulSets(meta.Namespace).Create(transform(&apps.StatefulSet{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "StatefulSet",
@@ -56,7 +56,7 @@ func PatchStatefulSetObject(c kubernetes.Interface, cur, mod *apps.StatefulSet) 
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching StatefulSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching StatefulSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.AppsV1().StatefulSets(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -72,7 +72,7 @@ func TryUpdateStatefulSet(c kubernetes.Interface, meta metav1.ObjectMeta, transf
 			result, e2 = c.AppsV1().StatefulSets(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update StatefulSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update StatefulSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/apps/v1beta1/deployment.go
+++ b/apps/v1beta1/deployment.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/appscode/go/types"
 	"github.com/appscode/kutil"
 	core_util "github.com/appscode/kutil/core/v1"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -18,7 +18,7 @@ import (
 func CreateOrPatchDeployment(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*apps.Deployment) *apps.Deployment) (*apps.Deployment, kutil.VerbType, error) {
 	cur, err := c.AppsV1beta1().Deployments(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Deployment %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Deployment %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.AppsV1beta1().Deployments(meta.Namespace).Create(transform(&apps.Deployment{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Deployment",
@@ -55,7 +55,7 @@ func PatchDeploymentObject(c kubernetes.Interface, cur, mod *apps.Deployment) (*
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Deployment %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching Deployment %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.AppsV1beta1().Deployments(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -71,7 +71,7 @@ func TryUpdateDeployment(c kubernetes.Interface, meta metav1.ObjectMeta, transfo
 			result, e2 = c.AppsV1beta1().Deployments(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update Deployment %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update Deployment %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/apps/v1beta1/statefulset.go
+++ b/apps/v1beta1/statefulset.go
@@ -5,7 +5,7 @@ import (
 	atypes "github.com/appscode/go/types"
 	"github.com/appscode/kutil"
 	core_util "github.com/appscode/kutil/core/v1"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -19,7 +19,7 @@ import (
 func CreateOrPatchStatefulSet(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*apps.StatefulSet) *apps.StatefulSet) (*apps.StatefulSet, kutil.VerbType, error) {
 	cur, err := c.AppsV1beta1().StatefulSets(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating StatefulSet %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating StatefulSet %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.AppsV1beta1().StatefulSets(meta.Namespace).Create(transform(&apps.StatefulSet{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "StatefulSet",
@@ -56,7 +56,7 @@ func PatchStatefulSetObject(c kubernetes.Interface, cur, mod *apps.StatefulSet) 
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching StatefulSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching StatefulSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.AppsV1beta1().StatefulSets(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -72,7 +72,7 @@ func TryUpdateStatefulSet(c kubernetes.Interface, meta metav1.ObjectMeta, transf
 			result, e2 = c.AppsV1beta1().StatefulSets(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update StatefulSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update StatefulSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/batch/v1/job.go
+++ b/batch/v1/job.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"github.com/appscode/go/types"
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	batch "k8s.io/api/batch/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -17,7 +17,7 @@ import (
 func CreateOrPatchJob(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*batch.Job) *batch.Job) (*batch.Job, kutil.VerbType, error) {
 	cur, err := c.BatchV1().Jobs(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Job %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Job %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.BatchV1().Jobs(meta.Namespace).Create(transform(&batch.Job{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Job",
@@ -54,7 +54,7 @@ func PatchJobObject(c kubernetes.Interface, cur, mod *batch.Job) (*batch.Job, ku
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Job %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching Job %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.BatchV1().Jobs(cur.Namespace).Patch(cur.Name, ktypes.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -70,7 +70,7 @@ func TryUpdateJob(c kubernetes.Interface, meta metav1.ObjectMeta, transform func
 			result, e2 = c.BatchV1().Jobs(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update Job %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update Job %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/batch/v1beta1/cronjob.go
+++ b/batch/v1beta1/cronjob.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	batch "k8s.io/api/batch/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchCronJob(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*batch.CronJob) *batch.CronJob) (*batch.CronJob, kutil.VerbType, error) {
 	cur, err := c.BatchV1beta1().CronJobs(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating CronJob %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating CronJob %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.BatchV1beta1().CronJobs(meta.Namespace).Create(transform(&batch.CronJob{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "CronJob",
@@ -53,7 +53,7 @@ func PatchCronJobObject(c kubernetes.Interface, cur, mod *batch.CronJob) (*batch
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching CronJob %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching CronJob %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.BatchV1beta1().CronJobs(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateCronJob(c kubernetes.Interface, meta metav1.ObjectMeta, transform 
 			result, e2 = c.BatchV1beta1().CronJobs(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update CronJob %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update CronJob %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/certificates/v1beta1/csr.go
+++ b/certificates/v1beta1/csr.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	certificates "k8s.io/api/certificates/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchCSR(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*certificates.CertificateSigningRequest) *certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, kutil.VerbType, error) {
 	cur, err := c.CertificatesV1beta1().CertificateSigningRequests().Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating CertificateSigningRequest %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating CertificateSigningRequest %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.CertificatesV1beta1().CertificateSigningRequests().Create(transform(&certificates.CertificateSigningRequest{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "CertificateSigningRequest",
@@ -53,7 +53,7 @@ func PatchCSRObject(c kubernetes.Interface, cur, mod *certificates.CertificateSi
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching CertificateSigningRequest %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching CertificateSigningRequest %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.CertificatesV1beta1().CertificateSigningRequests().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateCSR(c kubernetes.Interface, meta metav1.ObjectMeta, transform func
 			result, e2 = c.CertificatesV1beta1().CertificateSigningRequests().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update CertificateSigningRequest %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update CertificateSigningRequest %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/core/v1/configmap.go
+++ b/core/v1/configmap.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchConfigMap(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*core.ConfigMap) *core.ConfigMap) (*core.ConfigMap, kutil.VerbType, error) {
 	cur, err := c.CoreV1().ConfigMaps(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating ConfigMap %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating ConfigMap %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.CoreV1().ConfigMaps(meta.Namespace).Create(transform(&core.ConfigMap{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ConfigMap",
@@ -53,7 +53,7 @@ func PatchConfigMapObject(c kubernetes.Interface, cur, mod *core.ConfigMap) (*co
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching ConfigMap %s/%s with %s", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching ConfigMap %s/%s with %s", cur.Namespace, cur.Name, string(patch))
 	out, err := c.CoreV1().ConfigMaps(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateConfigMap(c kubernetes.Interface, meta metav1.ObjectMeta, transfor
 			result, e2 = c.CoreV1().ConfigMaps(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update ConfigMap %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update ConfigMap %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/core/v1/endpoints.go
+++ b/core/v1/endpoints.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,7 +14,7 @@ import (
 func CreateOrPatchEndpoints(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*core.Endpoints) *core.Endpoints) (*core.Endpoints, kutil.VerbType, error) {
 	cur, err := c.CoreV1().Endpoints(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Endpoints %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Endpoints %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.CoreV1().Endpoints(meta.Namespace).Create(transform(&core.Endpoints{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Endpoints",
@@ -51,7 +51,7 @@ func PatchEndpointsObject(c kubernetes.Interface, cur, mod *core.Endpoints) (*co
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Endpoints %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching Endpoints %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.CoreV1().Endpoints(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }

--- a/core/v1/node.go
+++ b/core/v1/node.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchNode(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*core.Node) *core.Node) (*core.Node, kutil.VerbType, error) {
 	cur, err := c.CoreV1().Nodes().Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Node %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Node %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.CoreV1().Nodes().Create(transform(&core.Node{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Node",
@@ -53,7 +53,7 @@ func PatchNodeObject(c kubernetes.Interface, cur, mod *core.Node) (*core.Node, k
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Node %s with %s", cur.Name, string(patch))
+	klog.V(3).Infof("Patching Node %s with %s", cur.Name, string(patch))
 	out, err := c.CoreV1().Nodes().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateNode(c kubernetes.Interface, meta metav1.ObjectMeta, transform fun
 			result, e2 = c.CoreV1().Nodes().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update Node %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update Node %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/core/v1/pod.go
+++ b/core/v1/pod.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchPod(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*core.Pod) *core.Pod) (*core.Pod, kutil.VerbType, error) {
 	cur, err := c.CoreV1().Pods(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Pod %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Pod %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.CoreV1().Pods(meta.Namespace).Create(transform(&core.Pod{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Pod",
@@ -53,7 +53,7 @@ func PatchPodObject(c kubernetes.Interface, cur, mod *core.Pod) (*core.Pod, kuti
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Pod %s/%s with %s", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching Pod %s/%s with %s", cur.Namespace, cur.Name, string(patch))
 	out, err := c.CoreV1().Pods(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdatePod(c kubernetes.Interface, meta metav1.ObjectMeta, transform func
 			result, e2 = c.CoreV1().Pods(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update Pod %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update Pod %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/core/v1/pv.go
+++ b/core/v1/pv.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchPV(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*core.PersistentVolume) *core.PersistentVolume) (*core.PersistentVolume, kutil.VerbType, error) {
 	cur, err := c.CoreV1().PersistentVolumes().Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating PersistentVolume %s.", meta.Name)
+		klog.V(3).Infof("Creating PersistentVolume %s.", meta.Name)
 		out, err := c.CoreV1().PersistentVolumes().Create(transform(&core.PersistentVolume{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "PersistentVolume",
@@ -53,7 +53,7 @@ func PatchPVObject(c kubernetes.Interface, cur, mod *core.PersistentVolume) (*co
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching PersistentVolume %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching PersistentVolume %s with %s.", cur.Name, string(patch))
 	out, err := c.CoreV1().PersistentVolumes().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdatePV(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(
 			result, e2 = c.CoreV1().PersistentVolumes().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update PersistentVolume %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update PersistentVolume %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/core/v1/pvc.go
+++ b/core/v1/pvc.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchPVC(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*core.PersistentVolumeClaim) *core.PersistentVolumeClaim) (*core.PersistentVolumeClaim, kutil.VerbType, error) {
 	cur, err := c.CoreV1().PersistentVolumeClaims(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating PersistentVolumeClaim %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating PersistentVolumeClaim %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.CoreV1().PersistentVolumeClaims(meta.Namespace).Create(transform(&core.PersistentVolumeClaim{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "PersistentVolumeClaim",
@@ -53,7 +53,7 @@ func PatchPVCObject(c kubernetes.Interface, cur, mod *core.PersistentVolumeClaim
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching PersistentVolumeClaim %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching PersistentVolumeClaim %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.CoreV1().PersistentVolumeClaims(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdatePVC(c kubernetes.Interface, meta metav1.ObjectMeta, transform func
 			result, e2 = c.CoreV1().PersistentVolumeClaims(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update PersistentVolumeClaim %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update PersistentVolumeClaim %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/core/v1/rc.go
+++ b/core/v1/rc.go
@@ -3,7 +3,7 @@ package v1
 import (
 	. "github.com/appscode/go/types"
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -17,7 +17,7 @@ import (
 func CreateOrPatchRC(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*core.ReplicationController) *core.ReplicationController) (*core.ReplicationController, kutil.VerbType, error) {
 	cur, err := c.CoreV1().ReplicationControllers(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating ReplicationController %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating ReplicationController %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.CoreV1().ReplicationControllers(meta.Namespace).Create(transform(&core.ReplicationController{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ReplicationController",
@@ -54,7 +54,7 @@ func PatchRCObject(c kubernetes.Interface, cur, mod *core.ReplicationController)
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching ReplicationController %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching ReplicationController %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.CoreV1().ReplicationControllers(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -70,7 +70,7 @@ func TryUpdateRC(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(
 			result, e2 = c.CoreV1().ReplicationControllers(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update ReplicationController %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update ReplicationController %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/core/v1/service.go
+++ b/core/v1/service.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchService(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*core.Service) *core.Service) (*core.Service, kutil.VerbType, error) {
 	cur, err := c.CoreV1().Services(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Service %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Service %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.CoreV1().Services(meta.Namespace).Create(transform(&core.Service{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Service",
@@ -53,7 +53,7 @@ func PatchServiceObject(c kubernetes.Interface, cur, mod *core.Service) (*core.S
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Service %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching Service %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.CoreV1().Services(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateService(c kubernetes.Interface, meta metav1.ObjectMeta, transform 
 			result, e2 = c.CoreV1().Services(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update Service %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update Service %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/core/v1/serviceaccount.go
+++ b/core/v1/serviceaccount.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchServiceAccount(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*core.ServiceAccount) *core.ServiceAccount) (*core.ServiceAccount, kutil.VerbType, error) {
 	cur, err := c.CoreV1().ServiceAccounts(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating ServiceAccount %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating ServiceAccount %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.CoreV1().ServiceAccounts(meta.Namespace).Create(transform(&core.ServiceAccount{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ServiceAccount",
@@ -53,7 +53,7 @@ func PatchServiceAccountObject(c kubernetes.Interface, cur, mod *core.ServiceAcc
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching ServiceAccount %s/%s with %s", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching ServiceAccount %s/%s with %s", cur.Namespace, cur.Name, string(patch))
 	out, err := c.CoreV1().ServiceAccounts(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateServiceAccount(c kubernetes.Interface, meta metav1.ObjectMeta, tra
 			result, e2 = c.CoreV1().ServiceAccounts(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update ServiceAccount %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update ServiceAccount %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/discovery/lib.go
+++ b/discovery/lib.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	version "github.com/appscode/go-version"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
@@ -109,7 +109,7 @@ func IsSupportedVersion(kc kubernetes.Interface, constraint string, blackListedV
 	if err != nil {
 		return err
 	}
-	glog.Infof("Kubernetes version: %#v\n", info)
+	klog.Infof("Kubernetes version: %#v\n", info)
 
 	gv, err := version.NewVersion(info.GitVersion)
 	if err != nil {

--- a/discovery/restmapper.go
+++ b/discovery/restmapper.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/conversion"
@@ -40,7 +40,7 @@ func DetectResource(restmapper *DefaultRESTMapper, obj interface{}) (schema.Grou
 func ResourceForGVK(client discovery.DiscoveryInterface, input schema.GroupVersionKind) (schema.GroupVersionResource, error) {
 	resourceList, err := client.ServerResourcesForGroupVersion(input.GroupVersion().String())
 	if discovery.IsGroupDiscoveryFailedError(err) {
-		glog.Errorf("Skipping failed API Groups: %v", err)
+		klog.Errorf("Skipping failed API Groups: %v", err)
 	} else if err != nil {
 		return schema.GroupVersionResource{}, err
 	}
@@ -72,7 +72,7 @@ func LoadRestMapper(client discovery.DiscoveryInterface) (*DefaultRESTMapper, er
 
 	resourceLists, err := client.ServerResources()
 	if discovery.IsGroupDiscoveryFailedError(err) {
-		glog.Errorf("Skipping failed API Groups: %v", err)
+		klog.Errorf("Skipping failed API Groups: %v", err)
 	} else if err != nil {
 		return nil, err
 	}

--- a/dynamic/controllerref/unstructured.go
+++ b/dynamic/controllerref/unstructured.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/appscode/go/types"
 	dynamicclientset "github.com/appscode/kutil/dynamic/clientset"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -82,7 +82,7 @@ func (m *UnstructuredManager) adoptChild(obj *unstructured.Unstructured) error {
 	if err := m.CanAdopt(); err != nil {
 		return fmt.Errorf("can't adopt %v %v/%v (%v): %v", m.childKind.Kind, obj.GetNamespace(), obj.GetName(), obj.GetUID(), err)
 	}
-	glog.Infof("%v %v/%v: adopting %v %v", m.parentKind.Kind, m.Controller.GetNamespace(), m.Controller.GetName(), m.childKind.Kind, obj.GetName())
+	klog.Infof("%v %v/%v: adopting %v %v", m.parentKind.Kind, m.Controller.GetNamespace(), m.Controller.GetName(), m.childKind.Kind, obj.GetName())
 	controllerRef := metav1.OwnerReference{
 		APIVersion:         m.parentKind.GroupVersion().String(),
 		Kind:               m.parentKind.Kind,
@@ -105,7 +105,7 @@ func (m *UnstructuredManager) adoptChild(obj *unstructured.Unstructured) error {
 }
 
 func (m *UnstructuredManager) releaseChild(obj *unstructured.Unstructured) error {
-	glog.Infof("%v %v/%v: releasing %v %v", m.parentKind.Kind, m.Controller.GetNamespace(), m.Controller.GetName(), m.childKind.Kind, obj.GetName())
+	klog.Infof("%v %v/%v: releasing %v %v", m.parentKind.Kind, m.Controller.GetNamespace(), m.Controller.GetName(), m.childKind.Kind, obj.GetName())
 	_, err := m.client.UpdateWithRetries(obj, func(obj *unstructured.Unstructured) bool {
 		ownerRefs := removeOwnerReference(obj.GetOwnerReferences(), m.Controller.GetUID())
 		obj.SetOwnerReferences(ownerRefs)

--- a/dynamic/discovery/discovery.go
+++ b/dynamic/discovery/discovery.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -83,12 +83,12 @@ func (rm *ResourceMap) GetKind(apiVersion, kind string) (result *APIResource) {
 func (rm *ResourceMap) refresh() {
 	// Fetch all API Group-Versions and their resources from the server.
 	// We do this before acquiring the lock so we don't block readers.
-	glog.V(7).Info("Refreshing API discovery info")
+	klog.V(7).Info("Refreshing API discovery info")
 	groups, err := rm.discoveryClient.ServerResources()
 	if discovery.IsGroupDiscoveryFailedError(err) {
-		glog.Errorf("Skipping failed API Groups: %v", err)
+		klog.Errorf("Skipping failed API Groups: %v", err)
 	} else if err != nil {
-		glog.Errorf("Failed to fetch discovery info: %v", err)
+		klog.Errorf("Failed to fetch discovery info: %v", err)
 		return
 	}
 

--- a/dynamic/informer/factory.go
+++ b/dynamic/informer/factory.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	dynamicclientset "github.com/appscode/kutil/dynamic/clientset"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 // SharedInformerFactory is a factory for requesting dynamic informers from a
@@ -65,7 +65,7 @@ func (f *SharedInformerFactory) Resource(apiVersion, resource string) (*Resource
 	if sharedInformer, ok := f.sharedInformers[key]; ok {
 		count := f.refCount[key] + 1
 		f.refCount[key] = count
-		glog.V(4).Infof("Subscribed to shared informer for %v in %v (total subscribers now %v)", resource, apiVersion, count)
+		klog.V(4).Infof("Subscribed to shared informer for %v in %v (total subscribers now %v)", resource, apiVersion, count)
 		return newResourceInformer(sharedInformer), nil
 	}
 
@@ -85,7 +85,7 @@ func (f *SharedInformerFactory) Resource(apiVersion, resource string) (*Resource
 		defer f.mutex.Unlock()
 
 		count := f.refCount[key] - 1
-		glog.V(4).Infof("Unsubscribed from shared informer for %v in %v (total subscribers now %v)", resource, apiVersion, count)
+		klog.V(4).Infof("Unsubscribed from shared informer for %v in %v (total subscribers now %v)", resource, apiVersion, count)
 
 		if count > 0 {
 			// Others are still using it.
@@ -94,13 +94,13 @@ func (f *SharedInformerFactory) Resource(apiVersion, resource string) (*Resource
 		}
 
 		// We're the last ones using it.
-		glog.V(4).Infof("Stopping shared informer for %v in %v (no more subscribers)", resource, apiVersion)
+		klog.V(4).Infof("Stopping shared informer for %v in %v (no more subscribers)", resource, apiVersion)
 		close(stopCh)
 		delete(f.refCount, key)
 		delete(f.sharedInformers, key)
 	}
 
-	glog.V(4).Infof("Starting shared informer for %v in %v", resource, apiVersion)
+	klog.V(4).Infof("Starting shared informer for %v in %v", resource, apiVersion)
 	sharedInformer := newSharedResourceInformer(client, f.defaultResync, closeFn)
 	f.sharedInformers[key] = sharedInformer
 	f.refCount[key] = 1

--- a/dynamic/unstructured.go
+++ b/dynamic/unstructured.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +31,7 @@ func CreateOrPatch(
 
 	cur, err := ri.Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating %s %s/%s.", gvr.String(), meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating %s %s/%s.", gvr.String(), meta.Namespace, meta.Name)
 		u := &unstructured.Unstructured{}
 		u.SetName(meta.Name)
 		u.SetNamespace(meta.Namespace)
@@ -81,7 +81,7 @@ func PatchObject(
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching %s %s/%s with %s.", gvr.String(), cur.GetNamespace(), cur.GetName(), string(patch))
+	klog.V(3).Infof("Patching %s %s/%s with %s.", gvr.String(), cur.GetNamespace(), cur.GetName(), string(patch))
 	out, err := ri.Patch(cur.GetName(), types.MergePatchType, patch, metav1.UpdateOptions{})
 	return out, kutil.VerbPatched, err
 }
@@ -109,7 +109,7 @@ func TryUpdate(
 			result, e2 = ri.Update(transform(cur.DeepCopy()), metav1.UpdateOptions{})
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update %s %s/%s due to %v.", attempt, gvr.String(), cur.GetNamespace(), cur.GetName(), e2)
+		klog.Errorf("Attempt %d failed to update %s %s/%s due to %v.", attempt, gvr.String(), cur.GetNamespace(), cur.GetName(), e2)
 		return false, nil
 	})
 

--- a/extensions/v1beta1/daemonset.go
+++ b/extensions/v1beta1/daemonset.go
@@ -4,7 +4,7 @@ import (
 	"github.com/appscode/kutil"
 	core_util "github.com/appscode/kutil/core/v1"
 	"github.com/appscode/kutil/discovery"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	extensions "k8s.io/api/extensions/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -18,7 +18,7 @@ import (
 func CreateOrPatchDaemonSet(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*extensions.DaemonSet) *extensions.DaemonSet) (*extensions.DaemonSet, kutil.VerbType, error) {
 	cur, err := c.ExtensionsV1beta1().DaemonSets(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating DaemonSet %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating DaemonSet %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.ExtensionsV1beta1().DaemonSets(meta.Namespace).Create(transform(&extensions.DaemonSet{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "DaemonSet",
@@ -55,7 +55,7 @@ func PatchDaemonSetObject(c kubernetes.Interface, cur, mod *extensions.DaemonSet
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching DaemonSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching DaemonSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.ExtensionsV1beta1().DaemonSets(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	if ok, err := discovery.CheckAPIVersion(c.Discovery(), "<= 1.5"); err == nil && ok {
 		// https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
@@ -75,7 +75,7 @@ func TryUpdateDaemonSet(c kubernetes.Interface, meta metav1.ObjectMeta, transfor
 			result, e2 = c.ExtensionsV1beta1().DaemonSets(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update DaemonSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update DaemonSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/extensions/v1beta1/deployment.go
+++ b/extensions/v1beta1/deployment.go
@@ -3,7 +3,7 @@ package v1beta1
 import (
 	. "github.com/appscode/go/types"
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	extensions "k8s.io/api/extensions/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -17,7 +17,7 @@ import (
 func CreateOrPatchDeployment(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*extensions.Deployment) *extensions.Deployment) (*extensions.Deployment, kutil.VerbType, error) {
 	cur, err := c.ExtensionsV1beta1().Deployments(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Deployment %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Deployment %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.ExtensionsV1beta1().Deployments(meta.Namespace).Create(transform(&extensions.Deployment{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Deployment",
@@ -54,7 +54,7 @@ func PatchDeploymentObject(c kubernetes.Interface, cur, mod *extensions.Deployme
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Deployment %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching Deployment %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.ExtensionsV1beta1().Deployments(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -70,7 +70,7 @@ func TryUpdateDeployment(c kubernetes.Interface, meta metav1.ObjectMeta, transfo
 			result, e2 = c.ExtensionsV1beta1().Deployments(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update Deployment %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update Deployment %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/extensions/v1beta1/ingress.go
+++ b/extensions/v1beta1/ingress.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	extensions "k8s.io/api/extensions/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchIngress(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*extensions.Ingress) *extensions.Ingress) (*extensions.Ingress, kutil.VerbType, error) {
 	cur, err := c.ExtensionsV1beta1().Ingresses(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Ingress %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Ingress %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.ExtensionsV1beta1().Ingresses(meta.Namespace).Create(transform(&extensions.Ingress{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Ingress",
@@ -53,7 +53,7 @@ func PatchIngressObject(c kubernetes.Interface, cur, mod *extensions.Ingress) (*
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Ingress %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching Ingress %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.ExtensionsV1beta1().Ingresses(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateIngress(c kubernetes.Interface, meta metav1.ObjectMeta, transform 
 			result, e2 = c.ExtensionsV1beta1().Ingresses(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update Ingress %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update Ingress %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/extensions/v1beta1/replicaset.go
+++ b/extensions/v1beta1/replicaset.go
@@ -3,7 +3,7 @@ package v1beta1
 import (
 	. "github.com/appscode/go/types"
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	extensions "k8s.io/api/extensions/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -17,7 +17,7 @@ import (
 func CreateOrPatchReplicaSet(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*extensions.ReplicaSet) *extensions.ReplicaSet) (*extensions.ReplicaSet, kutil.VerbType, error) {
 	cur, err := c.ExtensionsV1beta1().ReplicaSets(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating ReplicaSet %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating ReplicaSet %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.ExtensionsV1beta1().ReplicaSets(meta.Namespace).Create(transform(&extensions.ReplicaSet{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ReplicaSet",
@@ -54,7 +54,7 @@ func PatchReplicaSetObject(c kubernetes.Interface, cur, mod *extensions.ReplicaS
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching ReplicaSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching ReplicaSet %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.ExtensionsV1beta1().ReplicaSets(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -70,7 +70,7 @@ func TryUpdateReplicaSet(c kubernetes.Interface, meta metav1.ObjectMeta, transfo
 			result, e2 = c.ExtensionsV1beta1().ReplicaSets(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update ReplicaSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update ReplicaSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/meta/arguments.go
+++ b/meta/arguments.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 func UpsertArgumentList(baseArgs []string, overrideArgs []string, protectedFlags ...string) []string {
@@ -97,7 +97,7 @@ func ParseArgumentListToMap(arguments []string) map[string]string {
 		// Warn in all other cases, but don't error out. This can happen only if the user has edited the argument list by hand, so they might know what they are doing
 		if err != nil {
 			if i != 0 {
-				glog.Warningf("WARNING: The component argument %q could not be parsed correctly. The argument must be of the form %q. Skipping...", arg, "--")
+				klog.Warningf("WARNING: The component argument %q could not be parsed correctly. The argument must be of the form %q. Skipping...", arg, "--")
 			}
 			continue
 		}

--- a/meta/hash.go
+++ b/meta/hash.go
@@ -10,7 +10,7 @@ import (
 	"github.com/appscode/go/log"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fatih/structs"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -133,9 +133,9 @@ func AlreadyObserved2(old, nu interface{}, enableStatusSubresource bool) bool {
 		}
 	}
 
-	if !match && bool(glog.V(log.LevelDebug)) {
+	if !match && bool(klog.V(log.LevelDebug)) {
 		diff := Diff(old, nu)
-		glog.V(log.LevelDebug).Infof("%s %s/%s has changed. Diff: %s", GetKind(old), oldObj.GetNamespace(), oldObj.GetName(), diff)
+		klog.V(log.LevelDebug).Infof("%s %s/%s has changed. Diff: %s", GetKind(old), oldObj.GetNamespace(), oldObj.GetName(), diff)
 	}
 	return match
 }

--- a/openapi/render.go
+++ b/openapi/render.go
@@ -6,7 +6,7 @@ import (
 	"net"
 
 	"github.com/go-openapi/spec"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -74,7 +74,7 @@ func RenderOpenAPISpec(cfg Config) (string, error) {
 
 	// TODO have a "real" external address
 	if err := recommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
-		glog.Fatal(fmt.Errorf("error creating self-signed certificates: %v", err))
+		klog.Fatal(fmt.Errorf("error creating self-signed certificates: %v", err))
 	}
 
 	serverConfig := genericapiserver.NewRecommendedConfig(cfg.Codecs)

--- a/policy/v1beta1/pdb.go
+++ b/policy/v1beta1/pdb.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	policy "k8s.io/api/policy/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchPodDisruptionBudget(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*policy.PodDisruptionBudget) *policy.PodDisruptionBudget) (*policy.PodDisruptionBudget, kutil.VerbType, error) {
 	cur, err := c.PolicyV1beta1().PodDisruptionBudgets(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating PodDisruptionBudget %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating PodDisruptionBudget %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.PolicyV1beta1().PodDisruptionBudgets(meta.Namespace).Create(transform(&policy.PodDisruptionBudget{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "PodDisruptionBudget",
@@ -53,7 +53,7 @@ func PatchPodDisruptionBudgetObject(c kubernetes.Interface, cur, mod *policy.Pod
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching PodDisruptionBudget %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching PodDisruptionBudget %s with %s.", cur.Name, string(patch))
 	out, err := c.PolicyV1beta1().PodDisruptionBudgets(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdatePodDisruptionBudget(c kubernetes.Interface, meta metav1.ObjectMeta
 			result, e2 = c.PolicyV1beta1().PodDisruptionBudgets(meta.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update PodDisruptionBudget %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update PodDisruptionBudget %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/policy/v1beta1/psp.go
+++ b/policy/v1beta1/psp.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	policy "k8s.io/api/policy/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchPodSecurityPolicy(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*policy.PodSecurityPolicy) *policy.PodSecurityPolicy) (*policy.PodSecurityPolicy, kutil.VerbType, error) {
 	cur, err := c.PolicyV1beta1().PodSecurityPolicies().Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating PodSecurityPolicy %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating PodSecurityPolicy %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.PolicyV1beta1().PodSecurityPolicies().Create(transform(&policy.PodSecurityPolicy{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "PodSecurityPolicy",
@@ -53,7 +53,7 @@ func PatchPodSecurityPolicyObject(c kubernetes.Interface, cur, mod *policy.PodSe
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching PodSecurityPolicy %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching PodSecurityPolicy %s with %s.", cur.Name, string(patch))
 	out, err := c.PolicyV1beta1().PodSecurityPolicies().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdatePodSecurityPolicy(c kubernetes.Interface, meta metav1.ObjectMeta, 
 			result, e2 = c.PolicyV1beta1().PodSecurityPolicies().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update PodSecurityPolicy %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update PodSecurityPolicy %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/rbac/v1/clusterrole.go
+++ b/rbac/v1/clusterrole.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	rbac "k8s.io/api/rbac/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchClusterRole(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*rbac.ClusterRole) *rbac.ClusterRole) (*rbac.ClusterRole, kutil.VerbType, error) {
 	cur, err := c.RbacV1().ClusterRoles().Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating ClusterRole %s.", meta.Name)
+		klog.V(3).Infof("Creating ClusterRole %s.", meta.Name)
 		out, err := c.RbacV1().ClusterRoles().Create(transform(&rbac.ClusterRole{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterRole",
@@ -53,7 +53,7 @@ func PatchClusterRoleObject(c kubernetes.Interface, cur, mod *rbac.ClusterRole) 
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching ClusterRole %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching ClusterRole %s with %s.", cur.Name, string(patch))
 	out, err := c.RbacV1().ClusterRoles().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateClusterRole(c kubernetes.Interface, meta metav1.ObjectMeta, transf
 			result, e2 = c.RbacV1().ClusterRoles().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update ClusterRole %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update ClusterRole %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/rbac/v1/clusterrolebinding.go
+++ b/rbac/v1/clusterrolebinding.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	rbac "k8s.io/api/rbac/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchClusterRoleBinding(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*rbac.ClusterRoleBinding) *rbac.ClusterRoleBinding) (*rbac.ClusterRoleBinding, kutil.VerbType, error) {
 	cur, err := c.RbacV1().ClusterRoleBindings().Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating ClusterRoleBinding %s.", meta.Name)
+		klog.V(3).Infof("Creating ClusterRoleBinding %s.", meta.Name)
 		out, err := c.RbacV1().ClusterRoleBindings().Create(transform(&rbac.ClusterRoleBinding{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterRoleBinding",
@@ -53,7 +53,7 @@ func PatchClusterRoleBindingObject(c kubernetes.Interface, cur, mod *rbac.Cluste
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching ClusterRoleBinding %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching ClusterRoleBinding %s with %s.", cur.Name, string(patch))
 	out, err := c.RbacV1().ClusterRoleBindings().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateClusterRoleBinding(c kubernetes.Interface, meta metav1.ObjectMeta,
 			result, e2 = c.RbacV1().ClusterRoleBindings().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update ClusterRoleBinding %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update ClusterRoleBinding %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/rbac/v1/role.go
+++ b/rbac/v1/role.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	rbac "k8s.io/api/rbac/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchRole(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*rbac.Role) *rbac.Role) (*rbac.Role, kutil.VerbType, error) {
 	cur, err := c.RbacV1().Roles(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Role %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Role %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.RbacV1().Roles(meta.Namespace).Create(transform(&rbac.Role{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Role",
@@ -53,7 +53,7 @@ func PatchRoleObject(c kubernetes.Interface, cur, mod *rbac.Role) (*rbac.Role, k
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Role %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching Role %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.RbacV1().Roles(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateRole(c kubernetes.Interface, meta metav1.ObjectMeta, transform fun
 			result, e2 = c.RbacV1().Roles(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update Role %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update Role %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/rbac/v1/rolebinding.go
+++ b/rbac/v1/rolebinding.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	rbac "k8s.io/api/rbac/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchRoleBinding(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*rbac.RoleBinding) *rbac.RoleBinding) (*rbac.RoleBinding, kutil.VerbType, error) {
 	cur, err := c.RbacV1().RoleBindings(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating RoleBinding %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating RoleBinding %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.RbacV1().RoleBindings(meta.Namespace).Create(transform(&rbac.RoleBinding{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "RoleBinding",
@@ -53,7 +53,7 @@ func PatchRoleBindingObject(c kubernetes.Interface, cur, mod *rbac.RoleBinding) 
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching RoleBinding %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching RoleBinding %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.RbacV1().RoleBindings(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateRoleBinding(c kubernetes.Interface, meta metav1.ObjectMeta, transf
 			result, e2 = c.RbacV1().RoleBindings(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update RoleBinding %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update RoleBinding %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/rbac/v1beta1/clusterrole.go
+++ b/rbac/v1beta1/clusterrole.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	rbac "k8s.io/api/rbac/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchClusterRole(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*rbac.ClusterRole) *rbac.ClusterRole) (*rbac.ClusterRole, kutil.VerbType, error) {
 	cur, err := c.RbacV1beta1().ClusterRoles().Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating ClusterRole %s.", meta.Name)
+		klog.V(3).Infof("Creating ClusterRole %s.", meta.Name)
 		out, err := c.RbacV1beta1().ClusterRoles().Create(transform(&rbac.ClusterRole{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterRole",
@@ -53,7 +53,7 @@ func PatchClusterRoleObject(c kubernetes.Interface, cur, mod *rbac.ClusterRole) 
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching ClusterRole %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching ClusterRole %s with %s.", cur.Name, string(patch))
 	out, err := c.RbacV1beta1().ClusterRoles().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateClusterRole(c kubernetes.Interface, meta metav1.ObjectMeta, transf
 			result, e2 = c.RbacV1beta1().ClusterRoles().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update ClusterRole %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update ClusterRole %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/rbac/v1beta1/clusterrolebinding.go
+++ b/rbac/v1beta1/clusterrolebinding.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	rbac "k8s.io/api/rbac/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchClusterRoleBinding(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*rbac.ClusterRoleBinding) *rbac.ClusterRoleBinding) (*rbac.ClusterRoleBinding, kutil.VerbType, error) {
 	cur, err := c.RbacV1beta1().ClusterRoleBindings().Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating ClusterRoleBinding %s.", meta.Name)
+		klog.V(3).Infof("Creating ClusterRoleBinding %s.", meta.Name)
 		out, err := c.RbacV1beta1().ClusterRoleBindings().Create(transform(&rbac.ClusterRoleBinding{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterRoleBinding",
@@ -53,7 +53,7 @@ func PatchClusterRoleBindingObject(c kubernetes.Interface, cur, mod *rbac.Cluste
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching ClusterRoleBinding %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching ClusterRoleBinding %s with %s.", cur.Name, string(patch))
 	out, err := c.RbacV1beta1().ClusterRoleBindings().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateClusterRoleBinding(c kubernetes.Interface, meta metav1.ObjectMeta,
 			result, e2 = c.RbacV1beta1().ClusterRoleBindings().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update ClusterRoleBinding %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update ClusterRoleBinding %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/rbac/v1beta1/role.go
+++ b/rbac/v1beta1/role.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	rbac "k8s.io/api/rbac/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchRole(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*rbac.Role) *rbac.Role) (*rbac.Role, kutil.VerbType, error) {
 	cur, err := c.RbacV1beta1().Roles(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating Role %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating Role %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.RbacV1beta1().Roles(meta.Namespace).Create(transform(&rbac.Role{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Role",
@@ -53,7 +53,7 @@ func PatchRoleObject(c kubernetes.Interface, cur, mod *rbac.Role) (*rbac.Role, k
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching Role %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching Role %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.RbacV1beta1().Roles(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateRole(c kubernetes.Interface, meta metav1.ObjectMeta, transform fun
 			result, e2 = c.RbacV1beta1().Roles(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update Role %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update Role %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/rbac/v1beta1/rolebinding.go
+++ b/rbac/v1beta1/rolebinding.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	rbac "k8s.io/api/rbac/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchRoleBinding(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*rbac.RoleBinding) *rbac.RoleBinding) (*rbac.RoleBinding, kutil.VerbType, error) {
 	cur, err := c.RbacV1beta1().RoleBindings(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating RoleBinding %s/%s.", meta.Namespace, meta.Name)
+		klog.V(3).Infof("Creating RoleBinding %s/%s.", meta.Namespace, meta.Name)
 		out, err := c.RbacV1beta1().RoleBindings(meta.Namespace).Create(transform(&rbac.RoleBinding{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "RoleBinding",
@@ -53,7 +53,7 @@ func PatchRoleBindingObject(c kubernetes.Interface, cur, mod *rbac.RoleBinding) 
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching RoleBinding %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
+	klog.V(3).Infof("Patching RoleBinding %s/%s with %s.", cur.Namespace, cur.Name, string(patch))
 	out, err := c.RbacV1beta1().RoleBindings(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateRoleBinding(c kubernetes.Interface, meta metav1.ObjectMeta, transf
 			result, e2 = c.RbacV1beta1().RoleBindings(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update RoleBinding %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update RoleBinding %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)
 		return false, nil
 	})
 

--- a/storage/v1/storageclass.go
+++ b/storage/v1/storageclass.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	storage "k8s.io/api/storage/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchStorageClass(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*storage.StorageClass) *storage.StorageClass) (*storage.StorageClass, kutil.VerbType, error) {
 	cur, err := c.StorageV1().StorageClasses().Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating StorageClass %s.", meta.Name)
+		klog.V(3).Infof("Creating StorageClass %s.", meta.Name)
 		out, err := c.StorageV1().StorageClasses().Create(transform(&storage.StorageClass{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "StorageClass",
@@ -53,7 +53,7 @@ func PatchStorageClassObject(c kubernetes.Interface, cur, mod *storage.StorageCl
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching StorageClass %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching StorageClass %s with %s.", cur.Name, string(patch))
 	out, err := c.StorageV1().StorageClasses().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateStorageClass(c kubernetes.Interface, meta metav1.ObjectMeta, trans
 			result, e2 = c.StorageV1().StorageClasses().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update StorageClass %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update StorageClass %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/storage/v1beta1/storageclass.go
+++ b/storage/v1beta1/storageclass.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/appscode/kutil"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	storage "k8s.io/api/storage/v1beta1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +16,7 @@ import (
 func CreateOrPatchStorageClass(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(*storage.StorageClass) *storage.StorageClass) (*storage.StorageClass, kutil.VerbType, error) {
 	cur, err := c.StorageV1beta1().StorageClasses().Get(meta.Name, metav1.GetOptions{})
 	if kerr.IsNotFound(err) {
-		glog.V(3).Infof("Creating StorageClass %s.", meta.Name)
+		klog.V(3).Infof("Creating StorageClass %s.", meta.Name)
 		out, err := c.StorageV1beta1().StorageClasses().Create(transform(&storage.StorageClass{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "StorageClass",
@@ -53,7 +53,7 @@ func PatchStorageClassObject(c kubernetes.Interface, cur, mod *storage.StorageCl
 	if len(patch) == 0 || string(patch) == "{}" {
 		return cur, kutil.VerbUnchanged, nil
 	}
-	glog.V(3).Infof("Patching StorageClass %s with %s.", cur.Name, string(patch))
+	klog.V(3).Infof("Patching StorageClass %s with %s.", cur.Name, string(patch))
 	out, err := c.StorageV1beta1().StorageClasses().Patch(cur.Name, types.StrategicMergePatchType, patch)
 	return out, kutil.VerbPatched, err
 }
@@ -69,7 +69,7 @@ func TryUpdateStorageClass(c kubernetes.Interface, meta metav1.ObjectMeta, trans
 			result, e2 = c.StorageV1beta1().StorageClasses().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
-		glog.Errorf("Attempt %d failed to update StorageClass %s due to %v.", attempt, cur.Name, e2)
+		klog.Errorf("Attempt %d failed to update StorageClass %s due to %v.", attempt, cur.Name, e2)
 		return false, nil
 	})
 

--- a/tools/backup/manager.go
+++ b/tools/backup/manager.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -147,7 +147,7 @@ func (mgr BackupManager) Backup(process processorFunc) error {
 				continue
 			}
 
-			glog.V(3).Infof("Taking backup of %s apiVersion:%s kind:%s", list.GroupVersion, r.Name, r.Kind)
+			klog.V(3).Infof("Taking backup of %s apiVersion:%s kind:%s", list.GroupVersion, r.Name, r.Kind)
 			mgr.config.GroupVersion = &gv
 			mgr.config.APIPath = "/apis"
 			if gv.Group == core.GroupName {

--- a/tools/clientcmd/client_config.go
+++ b/tools/clientcmd/client_config.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/appscode/kutil/meta"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/kubernetes"
@@ -101,7 +101,7 @@ func Fix(cfg *rest.Config) *rest.Config {
 				// AKS cluster
 
 				h := "https://" + host
-				glog.Infof("resetting Kubeconfig host to %s from %s for AKS to workaround https://github.com/Azure/AKS/issues/522", h, cfg.Host)
+				klog.Infof("resetting Kubeconfig host to %s from %s for AKS to workaround https://github.com/Azure/AKS/issues/522", h, cfg.Host)
 				cfg.Host = h
 			}
 		}

--- a/tools/controller/client_builder.go
+++ b/tools/controller/client_builder.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	core_util "github.com/appscode/kutil/core/v1"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	v1authenticationapi "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -61,7 +61,7 @@ func (b SimpleControllerClientBuilder) Config(name string) (*restclient.Config, 
 func (b SimpleControllerClientBuilder) ConfigOrDie(name string) *restclient.Config {
 	clientConfig, err := b.Config(name)
 	if err != nil {
-		glog.Fatal(err)
+		klog.Fatal(err)
 	}
 	return clientConfig
 }
@@ -77,7 +77,7 @@ func (b SimpleControllerClientBuilder) Client(name string) (clientset.Interface,
 func (b SimpleControllerClientBuilder) ClientOrDie(name string) clientset.Interface {
 	client, err := b.Client(name)
 	if err != nil {
-		glog.Fatal(err)
+		klog.Fatal(err)
 	}
 	return client
 }
@@ -142,15 +142,15 @@ func (b SAControllerClientBuilder) Config(name string) (*restclient.Config, erro
 				}
 				validConfig, valid, err := b.getAuthenticatedConfig(sa, string(secret.Data[v1.ServiceAccountTokenKey]))
 				if err != nil {
-					glog.Warningf("error validating API token for %s/%s in secret %s: %v", sa.Name, sa.Namespace, secret.Name, err)
+					klog.Warningf("error validating API token for %s/%s in secret %s: %v", sa.Name, sa.Namespace, secret.Name, err)
 					// continue watching for good tokens
 					return false, nil
 				}
 				if !valid {
-					glog.Warningf("secret %s contained an invalid API token for %s/%s", secret.Name, sa.Name, sa.Namespace)
+					klog.Warningf("secret %s contained an invalid API token for %s/%s", secret.Name, sa.Name, sa.Namespace)
 					// try to delete the secret containing the invalid token
 					if err := b.CoreClient.Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-						glog.Warningf("error deleting secret %s containing invalid API token for %s/%s: %v", secret.Name, sa.Name, sa.Namespace, err)
+						klog.Warningf("error deleting secret %s containing invalid API token for %s/%s: %v", secret.Name, sa.Name, sa.Namespace, err)
 					}
 					// continue watching for good tokens
 					return false, nil
@@ -204,14 +204,14 @@ func (b SAControllerClientBuilder) getAuthenticatedConfig(sa *v1.ServiceAccount,
 	tokenReview := &v1authenticationapi.TokenReview{Spec: v1authenticationapi.TokenReviewSpec{Token: token}}
 	if tokenResult, err := b.AuthenticationClient.TokenReviews().Create(tokenReview); err == nil {
 		if !tokenResult.Status.Authenticated {
-			glog.Warningf("Token for %s/%s did not authenticate correctly", sa.Name, sa.Namespace)
+			klog.Warningf("Token for %s/%s did not authenticate correctly", sa.Name, sa.Namespace)
 			return nil, false, nil
 		}
 		if tokenResult.Status.User.Username != username {
-			glog.Warningf("Token for %s/%s authenticated as unexpected username: %s", sa.Name, sa.Namespace, tokenResult.Status.User.Username)
+			klog.Warningf("Token for %s/%s authenticated as unexpected username: %s", sa.Name, sa.Namespace, tokenResult.Status.User.Username)
 			return nil, false, nil
 		}
-		glog.V(4).Infof("Verified credential for %s/%s", sa.Name, sa.Namespace)
+		klog.V(4).Infof("Verified credential for %s/%s", sa.Name, sa.Namespace)
 		return clientConfig, true, nil
 	}
 
@@ -225,7 +225,7 @@ func (b SAControllerClientBuilder) getAuthenticatedConfig(sa *v1.ServiceAccount,
 	}
 	err = client.Get().AbsPath("/apis").Do().Error()
 	if apierrors.IsUnauthorized(err) {
-		glog.Warningf("Token for %s/%s did not authenticate correctly: %v", sa.Name, sa.Namespace, err)
+		klog.Warningf("Token for %s/%s did not authenticate correctly: %v", sa.Name, sa.Namespace, err)
 		return nil, false, nil
 	}
 
@@ -235,7 +235,7 @@ func (b SAControllerClientBuilder) getAuthenticatedConfig(sa *v1.ServiceAccount,
 func (b SAControllerClientBuilder) ConfigOrDie(name string) *restclient.Config {
 	clientConfig, err := b.Config(name)
 	if err != nil {
-		glog.Fatal(err)
+		klog.Fatal(err)
 	}
 	return clientConfig
 }
@@ -251,7 +251,7 @@ func (b SAControllerClientBuilder) Client(name string) (clientset.Interface, err
 func (b SAControllerClientBuilder) ClientOrDie(name string) clientset.Interface {
 	client, err := b.Client(name)
 	if err != nil {
-		glog.Fatal(err)
+		klog.Fatal(err)
 	}
 	return client
 }

--- a/tools/controller/controller_ref_manager.go
+++ b/tools/controller/controller_ref_manager.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -222,7 +222,7 @@ func (m *PodControllerRefManager) AdoptPod(pod *v1.Pod) error {
 // ReleasePod sends a patch to free the pod from the control of the controller.
 // It returns the error if the patching fails. 404 and 422 errors are ignored.
 func (m *PodControllerRefManager) ReleasePod(pod *v1.Pod) error {
-	glog.V(2).Infof("patching pod %s_%s to remove its controllerRef to %s/%s:%s",
+	klog.V(2).Infof("patching pod %s_%s to remove its controllerRef to %s/%s:%s",
 		pod.Namespace, pod.Name, m.controllerKind.GroupVersion(), m.controllerKind.Kind, m.Controller.GetName())
 	deleteOwnerRefPatch := fmt.Sprintf(`{"metadata":{"ownerReferences":[{"$patch":"delete","uid":"%s"}],"uid":"%s"}}`, m.Controller.GetUID(), pod.UID)
 	err := m.podControl.PatchPod(pod.Namespace, pod.Name, []byte(deleteOwnerRefPatch))

--- a/tools/controller/controller_utils.go
+++ b/tools/controller/controller_utils.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -189,10 +189,10 @@ func (r RealPodControl) createPods(nodeName, namespace string, template *v1.PodT
 	} else {
 		accessor, err := meta.Accessor(object)
 		if err != nil {
-			glog.Errorf("parentObject does not have ObjectMeta, %v", err)
+			klog.Errorf("parentObject does not have ObjectMeta, %v", err)
 			return nil
 		}
-		glog.V(4).Infof("Controller %v created pod %v", accessor.GetName(), newPod.Name)
+		klog.V(4).Infof("Controller %v created pod %v", accessor.GetName(), newPod.Name)
 		r.Recorder.Eventf(object, v1.EventTypeNormal, SuccessfulCreatePodReason, "Created pod: %v", newPod.Name)
 	}
 	return nil
@@ -203,7 +203,7 @@ func (r RealPodControl) DeletePod(namespace string, podID string, object runtime
 	if err != nil {
 		return fmt.Errorf("object does not have ObjectMeta, %v", err)
 	}
-	glog.V(2).Infof("Controller %v deleting pod %v/%v", accessor.GetName(), namespace, podID)
+	klog.V(2).Infof("Controller %v deleting pod %v/%v", accessor.GetName(), namespace, podID)
 	if err := r.KubeClient.CoreV1().Pods(namespace).Delete(podID, nil); err != nil && !apierrors.IsNotFound(err) {
 		r.Recorder.Eventf(object, v1.EventTypeWarning, FailedDeletePodReason, "Error deleting: %v", err)
 		return fmt.Errorf("unable to delete pods: %v", err)

--- a/tools/docker/lib.go
+++ b/tools/docker/lib.go
@@ -10,7 +10,7 @@ import (
 	httpz "github.com/appscode/go/net/http"
 	manifestV2 "github.com/docker/distribution/manifest/schema2"
 	dockertypes "github.com/docker/docker/api/types"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -81,7 +81,7 @@ func ParseImageName(image string) (ref ImageRef, err error) {
 func PullManifest(ref ImageRef, keyring credentialprovider.DockerKeyring) (*reg.Registry, *dockertypes.AuthConfig, interface{}, error) {
 	creds, withCredentials := keyring.Lookup(ref.RepoToPull)
 	if !withCredentials {
-		glog.V(3).Infof("Pulling image %q without credentials", ref)
+		klog.V(3).Infof("Pulling image %q without credentials", ref)
 		auth := &dockertypes.AuthConfig{ServerAddress: ref.RegistryURL}
 		hub, mf, err := pullManifest(ref, auth)
 		return hub, auth, mf, err

--- a/tools/queue/handler.go
+++ b/tools/queue/handler.go
@@ -2,7 +2,7 @@ package queue
 
 import (
 	meta_util "github.com/appscode/kutil/meta"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -87,28 +87,28 @@ func NewObservableUpdateHandler(queue workqueue.RateLimitingInterface, enableSta
 func Enqueue(queue workqueue.RateLimitingInterface, obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		klog.Errorf("Couldn't get key for object %+v: %v", obj, err)
 		return
 	}
 	queue.Add(key)
 }
 
 func (h *QueueingEventHandler) OnAdd(obj interface{}) {
-	glog.V(6).Infof("Add event for %+v\n", obj)
+	klog.V(6).Infof("Add event for %+v\n", obj)
 	if h.enqueueAdd == nil || h.enqueueAdd(obj) {
 		Enqueue(h.queue, obj)
 	}
 }
 
 func (h *QueueingEventHandler) OnUpdate(oldObj, newObj interface{}) {
-	glog.V(6).Infof("Update event for %+v\n", newObj)
+	klog.V(6).Infof("Update event for %+v\n", newObj)
 	if h.enqueueUpdate == nil || h.enqueueUpdate(oldObj, newObj) {
 		Enqueue(h.queue, newObj)
 	}
 }
 
 func (h *QueueingEventHandler) OnDelete(obj interface{}) {
-	glog.V(6).Infof("Delete event for %+v\n", obj)
+	klog.V(6).Infof("Delete event for %+v\n", obj)
 	if h.enqueueDelete {
 		Enqueue(h.queue, obj)
 	}

--- a/tools/queue/worker.go
+++ b/tools/queue/worker.go
@@ -3,7 +3,7 @@ package queue
 import (
 	"time"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
@@ -41,7 +41,7 @@ func (w *Worker) Run(shutdown <-chan struct{}) {
 		<-shutdown
 
 		// Stop accepting messages into the Queue
-		glog.V(1).Infof("Shutting down %s Queue\n", w.name)
+		klog.V(1).Infof("Shutting down %s Queue\n", w.name)
 		w.queue.ShutDown()
 	}()
 }
@@ -73,11 +73,11 @@ func (w *Worker) processNextEntry() bool {
 		w.queue.Forget(key)
 		return true
 	}
-	glog.Errorf("Failed to process key %v. Reason: %s", key, err)
+	klog.Errorf("Failed to process key %v. Reason: %s", key, err)
 
 	// This controller retries 5 times if something goes wrong. After that, it stops trying.
 	if w.queue.NumRequeues(key) < w.maxRetries {
-		glog.Infof("Error syncing key %v: %v", key, err)
+		klog.Infof("Error syncing key %v: %v", key, err)
 
 		// Re-enqueue the key rate limited. Based on the rate limiter on the
 		// queue and the re-enqueue history, the key will be processed later again.
@@ -88,6 +88,6 @@ func (w *Worker) processNextEntry() bool {
 	w.queue.Forget(key)
 	// Report to an external entity that, even after several retries, we could not successfully process this key
 	runtime.HandleError(err)
-	glog.Infof("Dropping key %q out of the queue: %v", key, err)
+	klog.Infof("Dropping key %q out of the queue: %v", key, err)
 	return true
 }


### PR DESCRIPTION
When upgrading the dependencies to the kubernetes-1.13 version, I found many issues related to duplicated flag definitions that was originally cause by glog and klog living in the goenv.