### PR TITLE
Fix container resources in UpsertContainer func

### DIFF
--- a/core/v1/kubernetes.go
+++ b/core/v1/kubernetes.go
@@ -91,6 +91,7 @@ func UpsertContainer(containers []core.Container, upsert core.Container) []core.
 			container.Env = upsert.Env
 			container.VolumeMounts = upsert.VolumeMounts
 			container.VolumeDevices = upsert.VolumeDevices
+			container.Resources = upsert.Resources
 			containers[i] = container
 			return containers
 		}


### PR DESCRIPTION
curContainer:
```
        resources:
          limits:
            cpu: 700m
            memory: 800Mi
          requests:
            cpu: 700m
            memory: 800Mi

```

newContainer:
```
      resources:
        limits:
          memory: 800Mi
        requests:
          cpu: 700m
          memory: 800Mi

```

generated:
```
        resources:
          limits:
            cpu: 700m
            memory: 800Mi
          requests:
            cpu: 700m
            memory: 800Mi
```

The merged resource holds `limits.cpu`. 