### PR TITLE
Add preferredPort parameter in Available port Getter

### DIFF
--- a/tools/portforward/tunnel.go
+++ b/tools/portforward/tunnel.go
@@ -132,7 +132,7 @@ func (t *Tunnel) Close() {
 }
 
 func getAvailablePort(preferredPort int) (int, error) {
-	l, err := net.Listen("tcp", fmt.Sprintf(":%v", preferredPort))
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", preferredPort))
 	if err != nil {
 		return 0, err
 	}

--- a/tools/portforward/tunnel.go
+++ b/tools/portforward/tunnel.go
@@ -101,7 +101,7 @@ func (t *Tunnel) ForwardPort() error {
 	}
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", u)
 
-	local, err := getAvailablePort()
+	local, err := getAvailablePort(t.Local)
 	if err != nil {
 		return errors.Errorf("could not find an available port: %s", err)
 	}
@@ -131,8 +131,8 @@ func (t *Tunnel) Close() {
 	close(t.stopChan)
 }
 
-func getAvailablePort() (int, error) {
-	l, err := net.Listen("tcp", ":0")
+func getAvailablePort(preferredPort int) (int, error) {
+	l, err := net.Listen("tcp", fmt.Sprintf(":%v", preferredPort))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Kafka needs to port-forward its client svc to a port that is specified in Kafka advertised listeners config. This config is set on Kafka cluster bootstrap which can not be changed afterwards.
This change will take the local port set in the tunnel and ensure its availability. The local port will be 0 if it's not set before calling the `ForwardPort` method and a random port will be chosen for availability checking.  