### PR TITLE
Check owner-reference using name/namespace instead of UID

### DIFF
--- a/core/v1/kubernetes.go
+++ b/core/v1/kubernetes.go
@@ -446,9 +446,12 @@ func RemoveOwnerReference(dependent metav1.Object, owner metav1.Object) {
 
 // IsOwnedBy checks if the dependent has a owner reference to the given owner
 func IsOwnedBy(dependent metav1.Object, owner metav1.Object) (owned bool, controller bool) {
+	if dependent.GetNamespace() != owner.GetNamespace() {
+		return false, false
+	}
 	refs := dependent.GetOwnerReferences()
 	for i := range refs {
-		if refs[i].UID == owner.GetUID() {
+		if refs[i].Name == owner.GetName() {
 			return true, refs[i].Controller != nil && *refs[i].Controller
 		}
 	}


### PR DESCRIPTION
UIDs can change across backups and clusters. References should be compared using name and namespace.
Signed-off-by: HiranmoyChowdhury <hiranmoy@appscode.com>