### PR TITLE
Impersonate only ACE extras

### DIFF
--- a/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -161,7 +161,8 @@ func UpdateMutatingWebhookCABundle(config *rest.Config, webhookConfigName string
 		lw,
 		&reg.MutatingWebhookConfiguration{},
 		nil,
-		conditions...)
+		conditions...,
+	)
 	return err
 }
 
@@ -213,7 +214,8 @@ func SyncMutatingWebhookCABundle(config *rest.Config, webhookConfigName string) 
 				default:
 					return false, fmt.Errorf("unexpected event type: %v", event.Type)
 				}
-			})
+			},
+		)
 		utilruntime.Must(err)
 	}()
 	return

--- a/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -156,7 +156,8 @@ func UpdateValidatingWebhookCABundle(config *rest.Config, webhookConfigName stri
 		},
 	}, extraConditions...)
 
-	_, err = watchtools.UntilWithSync(ctx,
+	_, err = watchtools.UntilWithSync(
+		ctx,
 		lw,
 		&reg.ValidatingWebhookConfiguration{},
 		nil,
@@ -213,7 +214,8 @@ func SyncValidatingWebhookCABundle(config *rest.Config, webhookConfigName string
 				default:
 					return false, fmt.Errorf("unexpected event type: %v", event.Type)
 				}
-			})
+			},
+		)
 		utilruntime.Must(err)
 	}()
 	return

--- a/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -161,7 +161,8 @@ func UpdateMutatingWebhookCABundle(config *rest.Config, webhookConfigName string
 		lw,
 		&reg.MutatingWebhookConfiguration{},
 		nil,
-		conditions...)
+		conditions...,
+	)
 	return err
 }
 
@@ -213,7 +214,8 @@ func SyncMutatingWebhookCABundle(config *rest.Config, webhookConfigName string) 
 				default:
 					return false, fmt.Errorf("unexpected event type: %v", event.Type)
 				}
-			})
+			},
+		)
 		utilruntime.Must(err)
 	}()
 	return

--- a/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -156,7 +156,8 @@ func UpdateValidatingWebhookCABundle(config *rest.Config, webhookConfigName stri
 		},
 	}, extraConditions...)
 
-	_, err = watchtools.UntilWithSync(ctx,
+	_, err = watchtools.UntilWithSync(
+		ctx,
 		lw,
 		&reg.ValidatingWebhookConfiguration{},
 		nil,
@@ -213,7 +214,8 @@ func SyncValidatingWebhookCABundle(config *rest.Config, webhookConfigName string
 				default:
 					return false, fmt.Errorf("unexpected event type: %v", event.Type)
 				}
-			})
+			},
+		)
 		utilruntime.Must(err)
 	}()
 	return

--- a/client/delegated.go
+++ b/client/delegated.go
@@ -100,13 +100,38 @@ func (d *DelegatingClient) RestConfig() *restclient.Config {
 	return d.config
 }
 
+// aceExtraPrefix is the only extra-key namespace impersonated identities carry
+// through. See impersonableExtra.
+const aceExtraPrefix = "ace.appscode.com/"
+
+// impersonableExtra keeps only the ACE extras. Every other extra key is provider
+// bookkeeping injected by the apiserver or the platform -- Rancher's principalid,
+// EKS' arn, the reserved authentication.kubernetes.io/* keys -- and impersonating
+// any of them needs an `impersonate` grant on userextras/<key> that callers do not
+// hold, which fails the whole request during impersonation authorization. RBAC
+// ignores extras, so dropping them changes no authorization decision.
+func impersonableExtra(in map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(in))
+	for k, v := range in {
+		if strings.HasPrefix(k, aceExtraPrefix) {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func (d *DelegatingClient) Impersonate(u user.Info) (*restclient.Config, client.Client, error) {
+	extra := impersonableExtra(u.GetExtra())
+
 	config := restclient.CopyConfig(d.config)
 	config.Impersonate = restclient.ImpersonationConfig{
 		UserName: u.GetName(),
 		UID:      u.GetUID(),
 		Groups:   u.GetGroups(),
-		Extra:    u.GetExtra(),
+		Extra:    extra,
 	}
 
 	// share the transport between all clients
@@ -117,7 +142,7 @@ func (d *DelegatingClient) Impersonate(u user.Info) (*restclient.Config, client.
 				UserName: u.GetName(),
 				UID:      u.GetUID(),
 				Groups:   u.GetGroups(),
-				Extra:    u.GetExtra(),
+				Extra:    extra,
 			}, d.options.HTTPClient.Transport),
 		}
 	}

--- a/conditions/merge_strategies_test.go
+++ b/conditions/merge_strategies_test.go
@@ -28,7 +28,8 @@ import (
 func TestGetStepCounterMessage(t *testing.T) {
 	g := NewWithT(t)
 
-	groups := getConditionGroups(conditionsWithSource(&conditioned{},
+	groups := getConditionGroups(conditionsWithSource(
+		&conditioned{},
 		nil1,
 		true1, true1,
 		falseInfo1,

--- a/discovery/lib.go
+++ b/discovery/lib.go
@@ -223,7 +223,8 @@ func IsDefaultSupportedVersion(kc kubernetes.Interface) error {
 		kc,
 		DefaultConstraint,
 		DefaultBlackListedVersions,
-		DefaultBlackListedMultiMasterVersions)
+		DefaultBlackListedMultiMasterVersions,
+	)
 }
 
 func IsSupportedVersion(kc kubernetes.Interface, constraint string, blackListedVersions map[string]error, blackListedMultiMasterVersions map[string]error) error {

--- a/discovery/lib_test.go
+++ b/discovery/lib_test.go
@@ -54,7 +54,8 @@ func TestDefaultSupportedVersion(t *testing.T) {
 			tc.multiMaster,
 			DefaultConstraint,
 			DefaultBlackListedVersions,
-			DefaultBlackListedMultiMasterVersions)
+			DefaultBlackListedMultiMasterVersions,
+		)
 		if tc.err && err == nil {
 			t.Fatalf("expected error for input: %s", tc.version)
 		} else if !tc.err && err != nil {

--- a/dynamic/kubernetes.go
+++ b/dynamic/kubernetes.go
@@ -115,7 +115,8 @@ func untilHasKey(
 		},
 	}
 
-	_, err = watchtools.UntilWithSync(ctx,
+	_, err = watchtools.UntilWithSync(
+		ctx,
 		lw,
 		&unstructured.Unstructured{},
 		nil,

--- a/meta/preconditions.go
+++ b/meta/preconditions.go
@@ -37,7 +37,8 @@ func (s PreConditionSet) PreconditionFunc() []mergepatch.PreconditionFunc {
 	}
 
 	for _, field := range sets.List[string](s.Set) {
-		preconditions = append(preconditions,
+		preconditions = append(
+			preconditions,
 			RequireChainKeyUnchanged(field),
 		)
 	}

--- a/openapi/render.go
+++ b/openapi/render.go
@@ -86,7 +86,8 @@ func RenderOpenAPISpec(cfg Config) (string, error) {
 
 	// TODO: keep the generic API server from wanting this
 	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
-	cfg.Scheme.AddUnversionedTypes(unversioned,
+	cfg.Scheme.AddUnversionedTypes(
+		unversioned,
 		&metav1.Status{},
 		&metav1.APIVersions{},
 		&metav1.APIGroupList{},

--- a/tools/queue/handler.go
+++ b/tools/queue/handler.go
@@ -121,7 +121,7 @@ func NewReconcilableHandler(queue workqueue.TypedRateLimitingInterface[any], res
 			return !meta_util.MustAlreadyReconciled(o)
 		},
 		enqueueUpdate: func(old, nu any) bool {
-			return (nu.(metav1.Object)).GetDeletionTimestamp() != nil || !meta_util.MustAlreadyReconciled(nu)
+			return nu.(metav1.Object).GetDeletionTimestamp() != nil || !meta_util.MustAlreadyReconciled(nu)
 		},
 		enqueueDelete:       true,
 		restrictToNamespace: restrictToNamespace,


### PR DESCRIPTION
## Problem

`DelegatingClient.Impersonate` forwards **every** extra key from the caller's identity into the impersonation config (both the rest config and the impersonating round tripper).

Kubernetes authorizes impersonated extras **per key**, as a subresource: impersonating extra key `k` requires `impersonate` on `userextras/k` in `authentication.k8s.io`. Our components only hold that grant for `userextras/ace.appscode.com/org-id`. So any caller arriving with provider-injected extras had the entire request denied in impersonation authorization (round 1), before the impersonated user's own RBAC was ever consulted.

Real-world hit: a spoke cluster imported into ACE through Rancher. Rancher authenticates its own user and forwards `principalid`, `username`, `requesthost`, `requesttokenid` as extras; none is `ace.appscode.com/org-id`. Result:

```
userextras.authentication.k8s.io "local://user-5klht" is forbidden: User
"system:serviceaccount:kubeops:kube-ui-server" cannot impersonate resource
"userextras/principalid" in API group "authentication.k8s.io" at the cluster scope
```

On Kubernetes 1.36 the same denial surfaces through the new constrained-impersonation path with a much more confusing message (`cannot impersonate-on:user-info:get resource "appreleases" ...`). Granting the constrained verbs does not help: constrained impersonation additionally rejects extra keys that are not domain-prefixed, so bare keys like `principalid` can only ever go through the legacy path.

## Fix

Allowlist instead of pass-through: keep only `ace.appscode.com/*` extras, drop the rest.

Every platform invents its own extras — Rancher sends `principalid`/`username`, EKS sends `arn`/`sessionName`/`principalId`, OpenShift sends `scopes.authorization.openshift.io`, and the apiserver itself adds `authentication.kubernetes.io/*`. Chasing each of them with wider RBAC never converges; an allowlist is correct on any provider.

Standard RBAC ignores extras entirely, so on an ordinary cluster this changes no authorization decision.

## Compatibility note

This is a shared library, so the behavior change reaches every consumer of `Impersonate`, not just the caller that hit the bug. A consumer running a **custom authorization webhook that keys off provider extras** would see different decisions, since those extras no longer reach the apiserver. I checked `kubeops.dev/ui-server`; I have not audited the full consumer set — worth a second opinion from someone who knows whether any deployment relies on extras for authorization.

## Refs

- Impersonation docs: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation
- Constrained impersonation KEP-5284: https://kep.k8s.io/5284
- Upstream per-key extra authorization: `staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation/mode.go` (`authorizeExtra`)